### PR TITLE
docs: show -2- as target in next steps text

### DIFF
--- a/discobuilder/builder/cli.py
+++ b/discobuilder/builder/cli.py
@@ -116,7 +116,7 @@ def build_cli():
 
 def show_next_steps_summary(with_scratch=True, release="rhel-9", target=None):
     if not target:
-        target = f"discovery-1-{release}-candidate"
+        target = f"discovery-2-{release}-candidate"
 
     release_message = dedent(
         f"""


### PR DESCRIPTION
Whoops. I missed this string in my previous commit (acd0214).